### PR TITLE
openssl: Disable session tickets and session caching

### DIFF
--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -321,8 +321,7 @@ rb_init_ssl(void)
 #endif
 			);
 	SSL_CTX_set_verify(ssl_server_ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, verify_accept_all_cb);
-	SSL_CTX_set_session_id_context(ssl_server_ctx,
-			(const unsigned char *)"libratbox", 9);
+	SSL_CTX_set_session_cache_mode(ssl_server_ctx, SSL_SESS_CACHE_OFF);
 	SSL_CTX_set_cipher_list(ssl_server_ctx, "EECDH+HIGH:EDH+HIGH:HIGH:!aNULL");
 
 	/* Set ECDHE on OpenSSL 1.00+, but make sure it's actually available because redhat are dicks

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -316,6 +316,9 @@ rb_init_ssl(void)
 #ifdef SSL_OP_SINGLE_DH_USE
 			| SSL_OP_SINGLE_DH_USE
 #endif
+#ifdef SSL_OP_NO_TICKET
+			| SSL_OP_NO_TICKET
+#endif
 			);
 	SSL_CTX_set_verify(ssl_server_ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, verify_accept_all_cb);
 	SSL_CTX_set_session_id_context(ssl_server_ctx,
@@ -343,6 +346,11 @@ rb_init_ssl(void)
 			   get_ssl_error(ERR_get_error()));
 		ret = 0;
 	}
+
+#ifdef SSL_OP_NO_TICKET
+	SSL_CTX_set_options(ssl_client_ctx, SSL_OP_NO_TICKET);
+#endif
+
 	return ret;
 }
 


### PR DESCRIPTION
Session tickets:

> When using session tickets, the TLS server stores its session-specific state in a session ticket and sends the session ticket to the TLS client for storing. The client resumes a TLS session by sending the session ticket to the server, and the server resumes the TLS session according to the session-specific state in the ticket. The session ticket is encrypted and authenticated by the server, and the server verifies its validity before using its contents.

> One particular weakness of this method with OpenSSL is that it always limits encryption and authentication security of the transmitted TLS session ticket to AES128-CBC-SHA256, no matter what other TLS parameters were negotiated for the actual TLS session. This means that the state information (the TLS session ticket) is not as well protected as the TLS session itself. Of particular concern is OpenSSL's storage of the keys in an application-wide context (SSL_CTX), i.e. for the life of the application, and not allowing for re-keying of the AES128-CBC-SHA256 TLS session tickets without resetting the application-wide OpenSSL context

Session caching:

> In an ordinary full handshake, the server sends a session id as part of the ServerHello message. The client associates this session id with the server's IP address and TCP port, so that when the client connects again to that server, it can use the session id to shortcut the handshake. In the server, the session id maps to the cryptographic parameters previously negotiated, specifically the "master secret".

> The internal session cache size is SSL_SESSION_CACHE_MAX_SIZE_DEFAULT, currently 1024*20, so that up to 20000 sessions can be held.

Quotes are from the openssl manual and Wikipedia's TLS page.