### PR TITLE
m_sasl: add configuration option for the nick of the SASL agent

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -461,6 +461,14 @@ general {
 	default_operstring = "is an IRC Operator";
 	default_adminstring = "is a Server Administrator";
 	servicestring = "is a Network Service";
+
+	/*
+	 * Nick of the network's SASL agent. Used to check whether services are here,
+	 * SASL credentials are only sent to its server. Needs to be a service.
+	 *
+	 * Defaults to SaslServ if unspecified.
+	 */
+	sasl_service = "SaslServ";
 	disable_fake_channels = no;
 	tkline_expire_notices = no;
 	default_floodcount = 10;

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -955,6 +955,14 @@ general {
 	 */
 	servicestring = "is a Network Service";
 
+	/*
+	 * Nick of the network's SASL agent. Used to check whether services are here,
+	 * SASL credentials are only sent to its server. Needs to be a service.
+	 *
+	 * Defaults to SaslServ if unspecified.
+	 */
+	sasl_service = "SaslServ";
+
 	/* disable fake channels: disable local users joining fake versions
 	 * of channels, eg #foo^B^B.  Disables bold, mirc colour, reverse,
 	 * underline and hard space.  (ASCII 2, 3, 22, 31, 160 respectively).

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -151,6 +151,8 @@ struct config_file_entry
 	char *identifyservice;
 	char *identifycommand;
 
+	char *sasl_service;
+
 	char *fname_userlog;
 	char *fname_fuserlog;
 	char *fname_operlog;

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -2315,6 +2315,7 @@ static struct ConfEntry conf_general_table[] =
 	{ "kline_reason",	CF_QSTRING, NULL, REALLEN, &ConfigFileEntry.kline_reason },
 	{ "identify_service",	CF_QSTRING, NULL, REALLEN, &ConfigFileEntry.identifyservice },
 	{ "identify_command",	CF_QSTRING, NULL, REALLEN, &ConfigFileEntry.identifycommand },
+	{ "sasl_service",	CF_QSTRING, NULL, REALLEN, &ConfigFileEntry.sasl_service },
 
 	{ "anti_spam_exit_message_time", CF_TIME,  NULL, 0, &ConfigFileEntry.anti_spam_exit_message_time },
 	{ "disable_fake_channels",	 CF_YESNO, NULL, 0, &ConfigFileEntry.disable_fake_channels },

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -692,6 +692,7 @@ set_default_conf(void)
 	ConfigFileEntry.default_operstring = NULL;
 	ConfigFileEntry.default_adminstring = NULL;
 	ConfigFileEntry.servicestring = NULL;
+	ConfigFileEntry.sasl_service = NULL;
 
 	ConfigFileEntry.default_umodes = UMODE_INVISIBLE;
 	ConfigFileEntry.failed_oper_notice = YES;
@@ -885,6 +886,9 @@ validate_conf(void)
 
 	if (ConfigFileEntry.servicestring == NULL)
 		ConfigFileEntry.servicestring = rb_strdup("is a Network Service");
+
+	if (ConfigFileEntry.sasl_service == NULL)
+		ConfigFileEntry.sasl_service = rb_strdup("SaslServ");
 
 	/* RFC 1459 says 1 message per 2 seconds on average and bursts of
 	 * 5 messages are acceptable, so allow at least that.
@@ -1489,6 +1493,8 @@ clear_out_old_conf(void)
 	ConfigFileEntry.servicestring = NULL;
 	rb_free(ConfigFileEntry.kline_reason);
 	ConfigFileEntry.kline_reason = NULL;
+	rb_free(ConfigFileEntry.sasl_service);
+	ConfigFileEntry.sasl_service = NULL;
 
 	/* clean out log */
 	rb_free(ConfigFileEntry.fname_userlog);


### PR DESCRIPTION
This allows multiple improvements to m_sasl. With this change, the SASL
authentication gets aborted immediately when services are offline.
Additionally, we send the SASL ENCAP messages directly to the specified
SASL agent.