### PR TITLE
Make RAND_egd optional to support libressl

### DIFF
--- a/libratbox/configure.ac
+++ b/libratbox/configure.ac
@@ -329,6 +329,8 @@ if test "$cf_enable_openssl" != no; then
 	AC_CHECK_LIB(crypto, RAND_status, 
 		[cf_enable_openssl=yes],
 		[cf_enable_openssl=no])
+	AC_CHECK_LIB(crypto, RAND_egd,
+		AC_DEFINE(HAVE_RAND_EGD, 1, [Define if the libcrypto has RAND_egd]))
 fi
 
 if test "$cf_enable_openssl" != no; then

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -603,10 +603,12 @@ rb_init_prng(const char *path, prng_seed_t seed_type)
 
 	switch (seed_type)
 	{
+#ifdef HAVE_RAND_EGD
 	case RB_PRNG_EGD:
 		if(RAND_egd(path) == -1)
 			return -1;
 		break;
+#endif
 	case RB_PRNG_FILE:
 		if(RAND_load_file(path, -1) == -1)
 			return -1;


### PR DESCRIPTION
The [Entropy Gathering Daemon](http://egd.sourceforge.net/) is a very old piece of software that is supposed to be an alternative for random/urandom but hasn't been updated for over 10 years. Recently, libressl has removed this function.

This PR makes the the use of `RAND_egd` optional by checking for its existence while configuring libratbox. If no support for `RAND_egd` is present but requested, `rb_init_prng()` will return `-1`.

This is enough for full compatibility with libressl.