### PR TITLE
Make EGD conditional/fix LibreSSL build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -535,6 +535,8 @@ if test "$cf_enable_openssl" != no; then
 	fi
 fi
 
+AC_CHECK_LIB(crypto, RAND_egd, AC_DEFINE(HAVE_RAND_EGD, 1, [Define if the libcrypto has RAND_egd]))
+
 CPPFLAGS="$save_CPPFLAGS"
 LIBS="$save_LIBS"
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -579,7 +579,9 @@ rb_init_prng(const char *path, prng_seed_t seed_type)
 	switch (seed_type)
 	{
 	case RB_PRNG_EGD:
+#ifdef HAVE_RAND_EGD
 		if(RAND_egd(path) == -1)
+#endif
 			return -1;
 		break;
 	case RB_PRNG_FILE:


### PR DESCRIPTION
EGD is not required on any platform nowadays. This patch detects EGD and
makes pulling it in conditional.

Just saw that EGD is completely removed in 3.5? This patch allows legacy EGD when it exists but nothing should need it.