### PR TITLE
Update ciphersuite string to prohibit RC4

### DIFF
--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -322,7 +322,7 @@ rb_init_ssl(void)
 			);
 	SSL_CTX_set_verify(ssl_server_ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, verify_accept_all_cb);
 	SSL_CTX_set_session_cache_mode(ssl_server_ctx, SSL_SESS_CACHE_OFF);
-	SSL_CTX_set_cipher_list(ssl_server_ctx, "EECDH+HIGH:EDH+HIGH:HIGH:!aNULL");
+	SSL_CTX_set_cipher_list(ssl_server_ctx, "kEECDH+HIGH:kEDH+HIGH:HIGH:!RC4:!aNULL");
 
 	/* Set ECDHE on OpenSSL 1.00+, but make sure it's actually available because redhat are dicks
 	   and bastardise their OpenSSL for stupid reasons... */


### PR DESCRIPTION
This is in accordance with RFC 7465
<https://tools.ietf.org/html/rfc7465>

Also correct the key exchange mechanism strings; these should be
prefixed with 'k'.