### PR TITLE
Update NEWS & README.md

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -739,13 +739,13 @@ misc
 BUGS: Major bugs in this release are listed in BUGS
 
 BUG REPORTS: If you run this code and encounter problems, you must report
-via IRC to irc.atheme.org, #charybdis. For specific bugs you can use
-http://bugs-meta.atheme.org/ (Charybdis project).
+via IRC to irc.freenode.net, #charybdis. For specific bugs you can use
+https://github.com/atheme/charybdis/issues.
 
 Please include a gdb backtrace and keep the core file, binaries and 
 modules in case the developers need them.
 
-Other files recommended for reading: BUGS, README.FIRST, INSTALL
+Other files recommended for reading: README.md, INSTALL
 
 --------------------------------------------------------------------------------
 $Id: NEWS 3496 2007-05-30 10:22:01Z jilles $

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ used with an IRCv3-capable services implementation such as [Atheme][atheme] or [
 
 # tips
 
- * To report bugs in charybdis, visit us at irc.atheme.org #charybdis
+ * To report bugs in charybdis, visit us at irc.freenode.net #charybdis
 
  * Please read doc/index.txt to get an overview of the current documentation.
 


### PR DESCRIPTION
* Point to irc.freenode.net instead of irc.atheme.org. I know that it's
  CNAME to chat, but I think it's preferable to use the irc. subdomain
  to make it clear that it's IRC.
* Point to GitHub issue tracker instead of bugs-meta.atheme.org that
  doesn't exist
* Remove mentioning of BUGS file and change README.FIRST to README.md as
  the first doesn't exist and I think they are the same file.