### PR TITLE
Remove trailing space in CAP ACK.

### DIFF
--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -426,8 +426,10 @@ cap_req(struct Client *source_p, const char *arg)
 		}
 
 		strcat(pbuf[i], cap->name);
-		strcat(pbuf[i], " ");
-		plen += (cap->namelen + 1);
+		if (!finished) {
+			strcat(pbuf[i], " ");
+			plen += (cap->namelen + 1);
+		}
 	}
 
 	if(!finished)


### PR DESCRIPTION
Fixes https://github.com/atheme/charybdis/issues/110